### PR TITLE
Add CORS test component

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
@@ -7,6 +8,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient()
   ]
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,3 @@
-Hello World! From Angular Part 2
+<h1>Hello, my-workspace</h1>
+<p>Hello World! From Angular Part 2</p>
+<app-cors-test></app-cors-test>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,9 +1,11 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { HttpClientModule } from '@angular/common/http';
+import { CorsTestComponent } from './cors-test.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, HttpClientModule, CorsTestComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/cors-test.component.ts
+++ b/src/app/cors-test.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-cors-test',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <button (click)="callApi()">Call API</button>
+    <div *ngIf="result">{{ result }}</div>
+    <div *ngIf="error" style="color:red;">{{ error }}</div>
+  `,
+})
+export class CorsTestComponent {
+  result?: string;
+  error?: string;
+
+  constructor(private http: HttpClient) {}
+
+  callApi() {
+    this.result = undefined;
+    this.error = undefined;
+    this.http
+      .get('https://www.gritlabs.net/api/hello', { responseType: 'text' })
+      .subscribe({
+        next: (res) => (this.result = res),
+        error: (err) => (this.error = err.message),
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- provide HttpClient in application config
- show CORS test component in root component
- implement `CorsTestComponent` with a button to call the API
- adjust the root template for tests

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68749cf81854832d96ec48f9e44673ac