### PR TITLE
Implement Angular Material task list UI

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -88,5 +88,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "my-workspace",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^20.1.0",
+        "@angular/cdk": "^20.1.0",
         "@angular/common": "^20.1.0",
         "@angular/compiler": "^20.1.0",
         "@angular/core": "^20.1.0",
         "@angular/forms": "^20.1.0",
+        "@angular/material": "^20.1.0",
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
         "rxjs": "~7.8.0",
@@ -107,6 +110,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.1.0.tgz",
+      "integrity": "sha512-5ILngsvu5VPQYaIm7lRyegZaDaAEtLUIPSS8h1dzWPaCxBIJ4uwzx9RDMiF32zhbxi+q0mAO2w2FdDlzWTT3og==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.1.0",
+        "@angular/core": "20.1.0"
       }
     },
     "node_modules/@angular/build": {
@@ -206,6 +225,21 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.1.0.tgz",
+      "integrity": "sha512-JhgbSOv7xZqWNZjuCh8A3A7pGv0mhtmGjHo36157LrxRO6R7x2yJJjxC5nQeroKZWhgN+X/jG/EJlzEvl9PxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -392,6 +426,23 @@
         "@angular/common": "20.1.0",
         "@angular/core": "20.1.0",
         "@angular/platform-browser": "20.1.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-20.1.0.tgz",
+      "integrity": "sha512-LfGz/V/kZwRIhzIZBiurM4Wc5CQiiJkiOChUfoEOvQLN2hckPFZbbvtg6JwxxA6nhzsDhuGHbj7Xj5dNsLfZLw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "20.1.0",
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@angular/forms": "^20.0.0 || ^21.0.0",
+        "@angular/platform-browser": "^20.0.0 || ^21.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -7275,7 +7326,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -7329,7 +7379,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^20.1.0",
+    "@angular/cdk": "^20.1.0",
     "@angular/common": "^20.1.0",
     "@angular/compiler": "^20.1.0",
     "@angular/core": "^20.1.0",
     "@angular/forms": "^20.1.0",
+    "@angular/material": "^20.1.0",
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
     "rxjs": "~7.8.0",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
 
 import { routes } from './app.routes';
 
@@ -9,6 +10,7 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient()
+    provideHttpClient(),
+    provideAnimations()
   ]
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,3 +1,1 @@
-<h1>Hello, my-workspace</h1>
-<p>Hello World! From Angular Part 2</p>
-<app-cors-test></app-cors-test>
+<app-task-list></app-task-list>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -14,10 +14,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render task list heading', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, my-workspace');
+    expect(compiled.textContent).toContain('Task List');
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,14 +1,13 @@
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
-import { CorsTestComponent } from './cors-test.component';
+import { TaskListComponent } from './tasks/task-list.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, HttpClientModule, CorsTestComponent],
+  standalone: true,
+  imports: [RouterOutlet, HttpClientModule, TaskListComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
-export class App {
-  protected readonly title = signal('my-workspace');
-}
+export class App {}

--- a/src/app/tasks/confirm-dialog.component.ts
+++ b/src/app/tasks/confirm-dialog.component.ts
@@ -1,0 +1,20 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  template: `
+    <h2 mat-dialog-title>{{ data.title }}</h2>
+    <mat-dialog-content>{{ data.message }}</mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close="false">No</button>
+      <button mat-raised-button color="warn" mat-dialog-close="true">Yes</button>
+    </mat-dialog-actions>
+  `,
+  imports: [MatDialogModule, MatButtonModule]
+})
+export class ConfirmDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { title: string; message: string }) {}
+}

--- a/src/app/tasks/task-dialog.component.css
+++ b/src/app/tasks/task-dialog.component.css
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/src/app/tasks/task-dialog.component.html
+++ b/src/app/tasks/task-dialog.component.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title>{{ data ? 'Edit Task' : 'New Task' }}</h2>
+<form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content>
+  <mat-form-field appearance="fill" class="full-width">
+    <mat-label>Title</mat-label>
+    <input matInput formControlName="title" required />
+  </mat-form-field>
+  <mat-form-field appearance="fill" class="full-width">
+    <mat-label>Description</mat-label>
+    <textarea matInput formControlName="description"></textarea>
+  </mat-form-field>
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="dialogRef.close()">Cancel</button>
+    <button mat-raised-button color="primary" type="submit">Save</button>
+  </mat-dialog-actions>
+</form>

--- a/src/app/tasks/task-dialog.component.ts
+++ b/src/app/tasks/task-dialog.component.ts
@@ -1,0 +1,42 @@
+import { Component, Inject, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-task-dialog',
+  standalone: true,
+  templateUrl: './task-dialog.component.html',
+  styleUrls: ['./task-dialog.component.css'],
+  imports: [
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDialogModule
+  ]
+})
+export class TaskDialogComponent {
+  private fb = inject(FormBuilder);
+  form = this.fb.nonNullable.group({
+    title: ['', Validators.required],
+    description: ['']
+  });
+
+  constructor(
+    private dialogRef: MatDialogRef<TaskDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data?: { title: string; description: string }
+  ) {
+    if (data) {
+      this.form.patchValue(data);
+    }
+  }
+
+  submit() {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+}

--- a/src/app/tasks/task-list.component.css
+++ b/src/app/tasks/task-list.component.css
@@ -1,0 +1,13 @@
+.table-container {
+  overflow: auto;
+}
+.fab {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+}
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}

--- a/src/app/tasks/task-list.component.html
+++ b/src/app/tasks/task-list.component.html
@@ -1,0 +1,38 @@
+<mat-toolbar color="primary">
+  <span>Task List</span>
+</mat-toolbar>
+<mat-card>
+  <div class="table-container" *ngIf="!loading; else loadingTpl">
+    <table mat-table [dataSource]="tasks" class="mat-elevation-z8">
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef>Title</th>
+        <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+      </ng-container>
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef>Description</th>
+        <td mat-cell *matCellDef="let element">{{ element.description }}</td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Actions</th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-icon-button color="primary" (click)="editTask(element)">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="deleteTask(element)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="loading">
+      <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
+    </div>
+  </ng-template>
+</mat-card>
+<button mat-fab color="primary" class="fab" (click)="openCreateDialog()">
+  <mat-icon>add</mat-icon>
+</button>

--- a/src/app/tasks/task-list.component.ts
+++ b/src/app/tasks/task-list.component.ts
@@ -1,0 +1,117 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatCardModule } from '@angular/material/card';
+import { TaskService, Task } from './task.service';
+import { TaskDialogComponent } from './task-dialog.component';
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+@Component({
+  selector: 'app-task-list',
+  standalone: true,
+  templateUrl: './task-list.component.html',
+  styleUrls: ['./task-list.component.css'],
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatToolbarModule,
+    MatCardModule
+  ]
+})
+export class TaskListComponent implements OnInit {
+  tasks: Task[] = [];
+  loading = false;
+  displayedColumns = ['title', 'description', 'actions'];
+
+  constructor(
+    private taskService: TaskService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit() {
+    this.loadTasks();
+  }
+
+  loadTasks() {
+    this.loading = true;
+    this.taskService.getTasks().subscribe({
+      next: (tasks) => {
+        this.tasks = tasks;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.snackBar.open(err.message || 'Failed to load tasks', 'Close', { duration: 3000 });
+      }
+    });
+  }
+
+  openCreateDialog() {
+    const dialogRef = this.dialog.open(TaskDialogComponent);
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.loading = true;
+        this.taskService.createTask(result).subscribe({
+          next: () => {
+            this.snackBar.open('Task created', 'Close', { duration: 3000 });
+            this.loadTasks();
+          },
+          error: (err) => {
+            this.loading = false;
+            this.snackBar.open(err.message || 'Failed to create task', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  editTask(task: Task) {
+    const dialogRef = this.dialog.open(TaskDialogComponent, { data: { title: task.title, description: task.description } });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.loading = true;
+        this.taskService.updateTask(task.id, result).subscribe({
+          next: () => {
+            this.snackBar.open('Task updated', 'Close', { duration: 3000 });
+            this.loadTasks();
+          },
+          error: (err) => {
+            this.loading = false;
+            this.snackBar.open(err.message || 'Failed to update task', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  deleteTask(task: Task) {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: { title: 'Delete Task', message: 'Are you sure you want to delete this task?' }
+    });
+    dialogRef.afterClosed().subscribe(confirmed => {
+      if (confirmed) {
+        this.loading = true;
+        this.taskService.deleteTask(task.id).subscribe({
+          next: () => {
+            this.snackBar.open('Task deleted', 'Close', { duration: 3000 });
+            this.loadTasks();
+          },
+          error: (err) => {
+            this.loading = false;
+            this.snackBar.open(err.message || 'Failed to delete task', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+}

--- a/src/app/tasks/task.service.ts
+++ b/src/app/tasks/task.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Task {
+  id: string;
+  title: string;
+  description: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TaskService {
+  private baseUrl = 'https://www.gritlabs.net';
+
+  constructor(private http: HttpClient) {}
+
+  getTasks(): Observable<Task[]> {
+    return this.http.get<Task[]>(`${this.baseUrl}/tasks/list`);
+  }
+
+  createTask(task: Omit<Task, 'id'>): Observable<Task> {
+    return this.http.post<Task>(`${this.baseUrl}/tasks/create`, task);
+  }
+
+  getTask(id: string): Observable<Task> {
+    return this.http.get<Task>(`${this.baseUrl}/tasks/${id}/details`);
+  }
+
+  updateTask(id: string, task: Omit<Task, 'id'>): Observable<Task> {
+    return this.http.put<Task>(`${this.baseUrl}/tasks/${id}/details`, task);
+  }
+
+  deleteTask(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/tasks/${id}/details`);
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <meta charset="utf-8">
   <title>MyWorkspace</title>
   <base href="/">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,2 @@
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
## Summary
- install Angular Material packages
- configure global animations and Material theme
- add Material icons link
- create TaskService for cross-site API calls
- build task dialog, confirm dialog, and table components
- show TaskList component in root app
- update unit test

## Testing
- `npm test --silent --unsafe-perm` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_6874a203fc10832dbdd570c472a737ec