### PR TITLE
Add Mutex Buttons widget

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,1 @@
-<app-task-list></app-task-list>
+<router-outlet></router-outlet>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,11 @@
 import { Routes } from '@angular/router';
+import { TaskListComponent } from './tasks/task-list.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: TaskListComponent },
+  {
+    path: 'mutex',
+    loadChildren: () =>
+      import('./widgets/mutex/mutex.module').then((m) => m.MutexModule),
+  },
+];

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -14,10 +14,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render task list heading', () => {
+  it('should render router outlet', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.textContent).toContain('Task List');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { TaskListComponent } from './tasks/task-list.component';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [HttpClientModule, TaskListComponent],
+  imports: [HttpClientModule, RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/widgets/mutex/mutex-buttons.component.css
+++ b/src/app/widgets/mutex/mutex-buttons.component.css
@@ -1,0 +1,16 @@
+.mutex-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+.inputs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.status {
+  font-weight: bold;
+}

--- a/src/app/widgets/mutex/mutex-buttons.component.html
+++ b/src/app/widgets/mutex/mutex-buttons.component.html
@@ -1,0 +1,19 @@
+<div class="mutex-container">
+  <button mat-raised-button color="primary" (click)="togglePower()" aria-label="Power">
+    {{ panelOn ? 'Turn Off' : 'Turn On' }}
+  </button>
+
+  <div class="inputs" *ngIf="panelOn">
+    <mat-button-toggle-group [value]="selectedInput" aria-label="Select input">
+      <mat-button-toggle
+        *ngFor="let input of inputs"
+        [value]="input"
+        (click)="chooseInput(input)"
+      >
+        {{ input }}
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <div class="status" aria-live="polite">{{ status }}</div>
+</div>

--- a/src/app/widgets/mutex/mutex-buttons.component.ts
+++ b/src/app/widgets/mutex/mutex-buttons.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { CommonModule } from '@angular/common';
+import { MutexService, MutexState } from './mutex.service';
+
+@Component({
+  selector: 'app-mutex-buttons',
+  templateUrl: './mutex-buttons.component.html',
+  styleUrls: ['./mutex-buttons.component.css'],
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatButtonToggleModule]
+})
+export class MutexButtonsComponent implements OnInit {
+  panelOn = false;
+  selectedInput: string | null = null;
+
+  readonly inputs = ['HDMI', 'VGA', 'HDMI Audio', '1/8\" Audio'];
+
+  constructor(private mutexService: MutexService) {}
+
+  ngOnInit() {
+    this.mutexService.getState().subscribe((state) => {
+      this.panelOn = state.panelOn;
+      this.selectedInput = state.input;
+    });
+  }
+
+  togglePower() {
+    this.panelOn = !this.panelOn;
+    if (!this.panelOn) {
+      this.selectedInput = null;
+    }
+    this.persistState();
+  }
+
+  chooseInput(input: string) {
+    if (!this.panelOn) {
+      return;
+    }
+    this.selectedInput = input;
+    this.persistState();
+  }
+
+  get status(): string {
+    if (!this.panelOn) {
+      return 'Panel Off';
+    }
+    return this.selectedInput ? `${this.selectedInput} selected` : 'Panel On';
+  }
+
+  private persistState() {
+    const state: MutexState = {
+      panelOn: this.panelOn,
+      input: this.selectedInput
+    };
+    this.mutexService.setState(state).subscribe();
+  }
+}

--- a/src/app/widgets/mutex/mutex.module.ts
+++ b/src/app/widgets/mutex/mutex.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { MutexButtonsComponent } from './mutex-buttons.component';
+
+@NgModule({
+  imports: [
+    MutexButtonsComponent,
+    RouterModule.forChild([{ path: '', component: MutexButtonsComponent }])
+  ]
+})
+export class MutexModule {}

--- a/src/app/widgets/mutex/mutex.service.ts
+++ b/src/app/widgets/mutex/mutex.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, of, tap } from 'rxjs';
+
+export interface MutexState {
+  panelOn: boolean;
+  input: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MutexService {
+  private baseUrl = 'https://www.gritlabs.net';
+  private storageKey = 'mutexState';
+
+  constructor(private http: HttpClient) {}
+
+  getState(): Observable<MutexState> {
+    return this.http
+      .get<MutexState>(`${this.baseUrl}/mutex/state`)
+      .pipe(
+        tap((state) => this.saveLocalState(state)),
+        catchError(() => of(this.getLocalState()))
+      );
+  }
+
+  setState(state: MutexState): Observable<void> {
+    this.saveLocalState(state);
+    return this.http
+      .post<void>(`${this.baseUrl}/mutex/state`, state)
+      .pipe(catchError(() => of(void 0)));
+  }
+
+  getLocalState(): MutexState {
+    const raw = localStorage.getItem(this.storageKey);
+    if (raw) {
+      try {
+        return JSON.parse(raw) as MutexState;
+      } catch {
+        // ignore parse error
+      }
+    }
+    return { panelOn: false, input: null };
+  }
+
+  private saveLocalState(state: MutexState) {
+    localStorage.setItem(this.storageKey, JSON.stringify(state));
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated `/mutex` route
- implement `MutexButtonsComponent` and `MutexService`
- create `MutexModule` for lazy loading
- switch app root to use router-outlet
- update unit test for router outlet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68756fef51b4832da082f9c16a751316