### PR TITLE
Fix mutex selectedInput mapping

### DIFF
--- a/src/app/widgets/mutex/mutex-buttons.component.ts
+++ b/src/app/widgets/mutex/mutex-buttons.component.ts
@@ -22,7 +22,7 @@ export class MutexButtonsComponent implements OnInit {
   ngOnInit() {
     this.mutexService.getState().subscribe((state) => {
       this.panelOn = state.panelOn;
-      this.selectedInput = state.input;
+      this.selectedInput = state.selectedInput;
     });
   }
 
@@ -52,7 +52,7 @@ export class MutexButtonsComponent implements OnInit {
   private persistState() {
     const state: MutexState = {
       panelOn: this.panelOn,
-      input: this.selectedInput
+      selectedInput: this.selectedInput
     };
     this.mutexService.setState(state).subscribe();
   }

--- a/src/app/widgets/mutex/mutex.service.ts
+++ b/src/app/widgets/mutex/mutex.service.ts
@@ -4,7 +4,7 @@ import { Observable, catchError, of, tap } from 'rxjs';
 
 export interface MutexState {
   panelOn: boolean;
-  input: string | null;
+  selectedInput: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -34,12 +34,20 @@ export class MutexService {
     const raw = localStorage.getItem(this.storageKey);
     if (raw) {
       try {
-        return JSON.parse(raw) as MutexState;
+        const parsed = JSON.parse(raw) as MutexState | { panelOn: boolean; input: string | null };
+        if (parsed && (parsed as any).selectedInput !== undefined) {
+          return parsed as MutexState;
+        }
+        if (parsed && (parsed as any).input !== undefined) {
+          const { panelOn, input } = parsed as any;
+          return { panelOn, selectedInput: input };
+        }
+        return parsed as MutexState;
       } catch {
         // ignore parse error
       }
     }
-    return { panelOn: false, input: null };
+    return { panelOn: false, selectedInput: null };
   }
 
   private saveLocalState(state: MutexState) {


### PR DESCRIPTION
## Summary
- rename `input` to `selectedInput` in `MutexState`
- persist and load new property name with backwards compatibility
- update `MutexButtonsComponent` to use the new field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687582f72598832d8c3522f0885deabe