### PR TITLE
Add Angular switch panel widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "widgets",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@angular/common": "^20.1.0",
+    "@angular/core": "^20.1.0",
+    "@angular/platform-browser": "^20.1.0",
+    "@angular/platform-browser-dynamic": "^20.1.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,28 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { Component } from '@angular/core';
+import { SwitchPanelComponent, PanelInput } from './switch-panel.component';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [SwitchPanelComponent],
+  template: `
+    <app-switch-panel [inputs]="inputs" [(value)]="value" [disabled]="disabled"></app-switch-panel>
+    <div style="margin-top:1rem;">
+      <button (click)="disabled = !disabled">Toggle Power ({{ disabled ? 'OFF' : 'ON' }})</button>
+      <p>Selected: {{ value }}</p>
+    </div>
+  `
+})
+export class AppComponent {
+  inputs: PanelInput[] = [
+    { id: 'hdmi', label: 'HDMI' },
+    { id: 'vga', label: 'VGA' },
+    { id: 'hdmi-audio', label: 'HDMI Audio' },
+    { id: 'aux', label: '1/8\" Audio' }
+  ];
+  value = 'hdmi';
+  disabled = false;
+}
+
+bootstrapApplication(AppComponent).catch(err => console.error(err));

--- a/src/switch-panel.component.ts
+++ b/src/switch-panel.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input } from '@angular/core';
+
+export interface PanelInput {
+  id: string;
+  label: string;
+}
+
+@Component({
+  selector: 'app-switch-panel',
+  standalone: true,
+  template: `
+    <div class="panel" [class.disabled]="disabled" role="radiogroup">
+      <label *ngFor="let input of inputs" class="switch" [class.active]="input.id === value">
+        <input type="radio" name="panelInput" [value]="input.id" [disabled]="disabled"
+               [checked]="input.id === value" (change)="select(input.id)" [attr.aria-label]="input.label">
+        <span class="rail">
+          <span class="thumb"></span>
+        </span>
+        <span class="label">{{ input.label }}</span>
+      </label>
+    </div>
+  `,
+  styles: [
+    `
+    :host { display: block; font-family: sans-serif; }
+    .panel { display: flex; gap: 1rem; }
+    .switch { position: relative; cursor: pointer; user-select: none; }
+    .switch input { display: none; }
+    .rail { display: inline-block; width: 60px; height: 24px; background: #444; border-radius: 12px; position: relative; box-shadow: inset 0 0 4px #000; }
+    .thumb { position: absolute; top: 2px; left: 2px; width: 20px; height: 20px; border-radius: 50%; background: #666; transition: left 0.2s; box-shadow: 0 0 6px rgba(0,0,0,0.6); }
+    .switch.active .rail { background: #2196F3; box-shadow: 0 0 8px #2196F3; }
+    .switch.active .thumb { left: 38px; background: #bbdefb; }
+    .switch.disabled { opacity: 0.5; cursor: default; }
+    .panel.disabled .switch { pointer-events: none; opacity: 0.5; }
+    .label { display: block; text-align: center; margin-top: 0.25rem; font-size: 0.75rem; }
+    `
+  ]
+})
+export class SwitchPanelComponent {
+  @Input() inputs: PanelInput[] = [];
+  @Input() value = '';
+  @Input() disabled = false;
+
+  select(id: string) {
+    if (!this.disabled && this.value !== id) {
+      this.value = id;
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "lib": ["es2015", "dom"],
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- set up minimal TypeScript build
- implement `SwitchPanelComponent` with illuminated switches
- add demo bootstrap in `main.ts`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68758eca3238832d945c1d6c0b27baed