### PR TITLE
Add Material FAB panel for mutex

### DIFF
--- a/src/app/widgets/mutex/mutex-buttons.component.css
+++ b/src/app/widgets/mutex/mutex-buttons.component.css
@@ -1,35 +1,37 @@
+.mutex-card {
+  max-width: 320px;
+  margin: 1rem auto;
+}
+
 .mutex-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem;
   gap: 1rem;
-}
-
-.power-button {
-  background: #29b6f6;
-  color: #fff;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.3s;
-}
-
-.power-button:hover {
-  background: #1a98d5;
+  padding: 1rem;
 }
 
 .inputs {
-  display: flex;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  width: 100%;
 }
 
-.inputs[aria-disabled='true'] {
-  opacity: 0.6;
-  pointer-events: none;
+.inputs button {
+  width: 100%;
 }
 
 .status {
-  font-weight: bold;
+  font-weight: 600;
+}
+
+.mutex-card.disabled {
+  opacity: 0.6;
+}
+
+.inputs button.selected.mat-mdc-button-disabled {
+  background-color: #e91e63 !important;
+  color: #fff !important;
+  opacity: 0.6;
 }

--- a/src/app/widgets/mutex/mutex-buttons.component.html
+++ b/src/app/widgets/mutex/mutex-buttons.component.html
@@ -1,19 +1,24 @@
-<div class="mutex-container">
-  <button class="power-button" (click)="togglePower()" aria-label="Power">
-    {{ panelOn ? 'Turn Off' : 'Turn On' }}
-  </button>
-
-  <div class="inputs" role="radiogroup" [attr.aria-disabled]="!panelOn">
-    <app-glow-switch
-      *ngFor="let input of inputs"
-      [name]="'inputs'"
-      [label]="input"
-      [value]="input"
-      [checked]="selectedInput === input"
-      [disabled]="!panelOn"
-      (changed)="chooseInput($event)"
-    ></app-glow-switch>
+<mat-card class="mutex-card" [class.disabled]="!panelOn">
+  <div class="mutex-container">
+    <button mat-raised-button color="primary" (click)="togglePower()" aria-label="Power toggle">
+      <mat-icon>{{ panelOn ? 'power_settings_new' : 'power_off' }}</mat-icon>
+      {{ panelOn ? 'Turn Off' : 'Turn On' }}
+    </button>
+    <div class="inputs" role="radiogroup">
+      <button
+        *ngFor="let input of inputs"
+        mat-fab-extended
+        [color]="selectedInput === input.label ? 'accent' : undefined"
+        [disabled]="!panelOn"
+        (click)="chooseInput(input.label)"
+        [attr.aria-label]="input.label"
+        [attr.aria-pressed]="selectedInput === input.label"
+        [ngClass]="{ selected: selectedInput === input.label }"
+      >
+        <mat-icon>{{ input.icon }}</mat-icon>
+        <span>{{ input.label }}</span>
+      </button>
+    </div>
+    <div class="status" aria-live="polite">{{ status }}</div>
   </div>
-
-  <div class="status" aria-live="polite">{{ status }}</div>
-</div>
+</mat-card>

--- a/src/app/widgets/mutex/mutex-buttons.component.ts
+++ b/src/app/widgets/mutex/mutex-buttons.component.ts
@@ -1,20 +1,27 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MutexService, MutexState } from './mutex.service';
-import { GlowSwitchComponent } from './glow-switch.component';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-mutex-buttons',
   templateUrl: './mutex-buttons.component.html',
   styleUrls: ['./mutex-buttons.component.css'],
   standalone: true,
-  imports: [CommonModule, GlowSwitchComponent]
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule]
 })
 export class MutexButtonsComponent implements OnInit {
   panelOn = false;
   selectedInput: string | null = null;
 
-  readonly inputs = ['HDMI', 'VGA', 'HDMI Audio', '1/8\" Audio'];
+  readonly inputs: { label: string; icon: string }[] = [
+    { label: 'HDMI', icon: 'settings_input_hdmi' },
+    { label: 'VGA', icon: 'display_settings' },
+    { label: 'HDMI Audio', icon: 'surround_sound' },
+    { label: '1/8" Audio', icon: 'headphones' },
+  ];
 
   constructor(private mutexService: MutexService) {}
 


### PR DESCRIPTION
## Summary
- refactor MutexButtons component to use Angular Material FABs in a card panel
- add icons and 2x2 grid layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875b5a80720832d92f6a0a01fb09562