### PR TITLE
Fix color binding for MutexButtons

### DIFF
--- a/src/app/widgets/mutex/mutex-buttons.component.html
+++ b/src/app/widgets/mutex/mutex-buttons.component.html
@@ -7,7 +7,8 @@
     <div class="inputs" role="radiogroup">
       <button
         *ngFor="let input of inputs"
-        mat-fab-extended
+        mat-fab
+        extended
         [color]="selectedInput === input.label ? 'accent' : undefined"
         [disabled]="!panelOn"
         (click)="chooseInput(input.label)"


### PR DESCRIPTION
## Summary
- fix extended FAB syntax in `MutexButtonsComponent`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6875bdce77b8832d81d7ec10262724a4