### PR TITLE
Add AG Grid crypto demo widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@angular/material": "^20.1.0",
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
+        "ag-grid-angular": "^34.0.1",
+        "ag-grid-community": "^34.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3533,6 +3535,35 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ag-charts-types": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-12.0.1.tgz",
+      "integrity": "sha512-AvAmoyuKG63UxrwGTU+T6f+EEE8tc4ksm7Ai9lJcaUHn9s4PU9hspAGl69GnZpAiIxzA5uCLDvG/Did5N2DB2A==",
+      "license": "MIT"
+    },
+    "node_modules/ag-grid-angular": {
+      "version": "34.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-34.0.1.tgz",
+      "integrity": "sha512-hYOTvPJlVW1iwv4TwtNIQSZfzFGV1fnMNNU78/cB6pyHNxrFYSH72U6idHlv9e9L7CWBGqDH6swMl2yYOfpuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-grid-community": "34.0.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 17.0.0",
+        "@angular/core": ">= 17.0.0"
+      }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "34.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-34.0.1.tgz",
+      "integrity": "sha512-EzSWOGS/zMm9cqLrJUM6T5e2fPA10c4j0ADMS7QLy6NvzeSeT+iUwoaVHz+QfIDVv69is9KwHs6EYCT87FT5eg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-charts-types": "12.0.1"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@angular/material": "^20.1.0",
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
+    "ag-grid-angular": "^34.0.1",
+    "ag-grid-community": "^34.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -30,6 +30,13 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./cors-test.component').then((m) => m.CorsTestComponent),
       },
+      {
+        path: 'widget/ag-grid-demo',
+        loadComponent: () =>
+          import('./widgets/ag-grid-crypto/ag-grid-crypto-demo.component').then(
+            (m) => m.AgGridCryptoDemoComponent
+          ),
+      },
     ],
   },
   {
@@ -48,5 +55,12 @@ export const routes: Routes = [
     path: 'cors-test',
     loadComponent: () =>
       import('./cors-test.component').then((m) => m.CorsTestComponent),
+  },
+  {
+    path: 'ag-grid-demo',
+    loadComponent: () =>
+      import('./widgets/ag-grid-crypto/ag-grid-crypto-demo.component').then(
+        (m) => m.AgGridCryptoDemoComponent
+      ),
   },
 ];

--- a/src/app/showcase/widgets-showcase.component.html
+++ b/src/app/showcase/widgets-showcase.component.html
@@ -5,6 +5,7 @@
       <a mat-list-item routerLink="widget/task-list" routerLinkActive="active" aria-label="Task List">Task List</a>
       <a mat-list-item routerLink="widget/mutex" routerLinkActive="active" aria-label="Mutex Buttons">Mutex Buttons</a>
       <a mat-list-item routerLink="widget/cors-test" routerLinkActive="active" aria-label="CORS Test">CORS Test</a>
+      <a mat-list-item routerLink="widget/ag-grid-demo" routerLinkActive="active" aria-label="AG Grid Demo">AG Grid Demo</a>
     </mat-nav-list>
   </mat-drawer>
   <mat-drawer-content>

--- a/src/app/widgets/ag-grid-crypto/ag-grid-crypto-demo.component.css
+++ b/src/app/widgets/ag-grid-crypto/ag-grid-crypto-demo.component.css
@@ -1,0 +1,20 @@
+:host {
+  display: block;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.grid-container {
+  width: 100%;
+  height: 600px;
+}
+
+.loading,
+.error {
+  text-align: center;
+  padding: 1rem;
+}

--- a/src/app/widgets/ag-grid-crypto/ag-grid-crypto-demo.component.html
+++ b/src/app/widgets/ag-grid-crypto/ag-grid-crypto-demo.component.html
@@ -1,0 +1,32 @@
+<mat-card>
+  <mat-card-title>
+    Live Cryptocurrency Market Data — Powered by AG Grid and CoinGecko
+  </mat-card-title>
+  <div class="actions">
+    <button mat-raised-button color="primary" (click)="reload()" aria-label="Reload Data">
+      Reload Data
+    </button>
+    <button mat-raised-button color="accent" (click)="exportCsv()" aria-label="Export CSV">
+      Export CSV
+    </button>
+  </div>
+  <div class="grid-container" *ngIf="!loading && !error">
+    <ag-grid-angular
+      class="ag-theme-alpine"
+      [columnDefs]="columnDefs"
+      [defaultColDef]="defaultColDef"
+      [rowData]="rowData"
+      rowSelection="single"
+      [groupDisplayType]="'groupRows'"
+      [pagination]="true"
+      [paginationPageSize]="20"
+      [animateRows]="true"
+      (gridReady)="onGridReady($event)"
+      style="width: 100%; height: 600px;"
+    ></ag-grid-angular>
+  </div>
+  <div class="loading" *ngIf="loading">
+    <mat-progress-spinner mode="indeterminate" aria-label="Loading"></mat-progress-spinner>
+  </div>
+  <div class="error" *ngIf="error">{{ error }}</div>
+</mat-card>

--- a/src/app/widgets/ag-grid-crypto/ag-grid-crypto-demo.component.ts
+++ b/src/app/widgets/ag-grid-crypto/ag-grid-crypto-demo.component.ts
@@ -1,0 +1,162 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { AgGridModule } from 'ag-grid-angular';
+import { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-ag-grid-crypto-demo',
+  standalone: true,
+  templateUrl: './ag-grid-crypto-demo.component.html',
+  styleUrls: ['./ag-grid-crypto-demo.component.css'],
+  imports: [
+    CommonModule,
+    AgGridModule,
+    MatCardModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+  ],
+})
+export class AgGridCryptoDemoComponent implements OnInit {
+  columnDefs: ColDef[] = [
+    {
+      headerName: '',
+      field: 'image',
+      width: 40,
+      sortable: false,
+      filter: false,
+      cellRenderer: (params: any) =>
+        `<img src="${params.value}" alt="${params.data.name} icon" width="20" height="20">`,
+    },
+    { headerName: 'Name', field: 'name' },
+    { headerName: 'Symbol', field: 'symbol', filter: 'agSetColumnFilter' },
+    {
+      headerName: 'Current Price',
+      field: 'current_price',
+      type: 'numericColumn',
+      valueFormatter: this.currencyFormatter,
+    },
+    {
+      headerName: 'Market Cap',
+      field: 'market_cap',
+      type: 'numericColumn',
+      valueFormatter: this.currencyFormatter,
+    },
+    {
+      headerName: 'Rank',
+      field: 'market_cap_rank',
+      type: 'numericColumn',
+    },
+    {
+      headerName: 'Total Volume',
+      field: 'total_volume',
+      type: 'numericColumn',
+      valueFormatter: this.currencyFormatter,
+    },
+    {
+      headerName: '24h %',
+      field: 'price_change_percentage_24h',
+      type: 'numericColumn',
+      valueFormatter: (p) => (p.value ? p.value.toFixed(2) + '%' : ''),
+      tooltipField: 'price_change_percentage_24h',
+    },
+    {
+      headerName: 'High 24h',
+      field: 'high_24h',
+      type: 'numericColumn',
+      valueFormatter: this.currencyFormatter,
+    },
+    {
+      headerName: 'Low 24h',
+      field: 'low_24h',
+      type: 'numericColumn',
+      valueFormatter: this.currencyFormatter,
+    },
+    {
+      headerName: 'Circulating Supply',
+      field: 'circulating_supply',
+      type: 'numericColumn',
+    },
+    { headerName: 'Rank Range', field: 'rankRange', rowGroup: true, hide: true },
+    { headerName: 'Notes', field: 'notes', editable: true },
+  ];
+
+  defaultColDef: ColDef = {
+    sortable: true,
+    filter: true,
+    resizable: true,
+    flex: 1,
+    minWidth: 100,
+  };
+
+  rowData: any[] = [];
+  loading = false;
+  error?: string;
+  private gridApi?: GridApi;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  onGridReady(params: GridReadyEvent) {
+    this.gridApi = params.api;
+  }
+
+  reload() {
+    this.loadData();
+  }
+
+  exportCsv() {
+    this.gridApi?.exportDataAsCsv();
+  }
+
+  private loadData() {
+    this.loading = true;
+    this.error = undefined;
+    this.http
+      .get<any[]>(
+        'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd'
+      )
+      .subscribe({
+        next: (data) => {
+          this.rowData = data.map((d) => ({
+            ...d,
+            rankRange: this.rankRange(d.market_cap_rank),
+            notes: '',
+          }));
+          this.loading = false;
+        },
+        error: (err) => {
+          this.error = err.message || 'Failed to load data';
+          this.loading = false;
+        },
+      });
+  }
+
+  private rankRange(rank: number): string {
+    if (rank <= 10) {
+      return 'Top 10';
+    }
+    if (rank <= 50) {
+      return '11-50';
+    }
+    if (rank <= 100) {
+      return '51-100';
+    }
+    return '100+';
+  }
+
+  private currencyFormatter(p: any) {
+    return p.value
+      ? Intl.NumberFormat('en-US', {
+          style: 'currency',
+          currency: 'USD',
+        }).format(p.value)
+      : '';
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AgGridCryptoDemoComponent` to demo AG Grid with CoinGecko data
- add menu link and routing for `/ag-grid-demo`
- install `ag-grid-community` and `ag-grid-angular`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875c3440880832da3a50c63ad514e21