### PR TITLE
Add AG Grid master-detail widget

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -63,4 +63,11 @@ export const routes: Routes = [
         (m) => m.AgGridCryptoDemoComponent
       ),
   },
+  {
+    path: 'master-detail',
+    loadComponent: () =>
+      import('./widgets/master-detail/master-detail-grid.component').then(
+        (m) => m.MasterDetailGridComponent
+      ),
+  },
 ];

--- a/src/app/widgets/master-detail/master-detail-grid.component.css
+++ b/src/app/widgets/master-detail/master-detail-grid.component.css
@@ -1,0 +1,33 @@
+:host {
+  display: block;
+  padding: 1rem;
+}
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.list-column {
+  flex: 2 1 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.detail-card {
+  flex: 1 1 300px;
+}
+
+.grid-wrapper {
+  width: 100%;
+  height: 300px;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 300px;
+}

--- a/src/app/widgets/master-detail/master-detail-grid.component.html
+++ b/src/app/widgets/master-detail/master-detail-grid.component.html
@@ -1,0 +1,46 @@
+<div class="container">
+  <div class="list-column">
+    <mat-card class="grid-card">
+      <mat-card-title>Users</mat-card-title>
+      <div class="grid-wrapper" *ngIf="!loadingUsers; else loadingUsersTpl">
+        <ag-grid-angular
+          class="ag-theme-alpine"
+          [rowData]="users"
+          [columnDefs]="userColumnDefs"
+          [defaultColDef]="defaultColDef"
+          rowSelection="single"
+          (rowSelected)="onUserSelected($event)"
+          style="width: 100%; height: 300px;"
+        ></ag-grid-angular>
+      </div>
+      <ng-template #loadingUsersTpl>
+        <div class="loading"><mat-progress-spinner mode="indeterminate"></mat-progress-spinner></div>
+      </ng-template>
+    </mat-card>
+
+    <mat-card class="grid-card">
+      <mat-card-title>Posts</mat-card-title>
+      <div class="grid-wrapper" *ngIf="!loadingPosts; else loadingPostsTpl">
+        <ag-grid-angular
+          class="ag-theme-alpine"
+          [rowData]="posts"
+          [columnDefs]="postColumnDefs"
+          [defaultColDef]="defaultColDef"
+          rowSelection="single"
+          (rowSelected)="onPostSelected($event)"
+          style="width: 100%; height: 300px;"
+        ></ag-grid-angular>
+      </div>
+      <ng-template #loadingPostsTpl>
+        <div class="loading"><mat-progress-spinner mode="indeterminate"></mat-progress-spinner></div>
+      </ng-template>
+    </mat-card>
+  </div>
+
+  <mat-card class="detail-card" *ngIf="selectedPost">
+    <mat-card-title>{{ selectedPost.title }}</mat-card-title>
+    <mat-card-content>
+      <p>{{ selectedPost.body }}</p>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/widgets/master-detail/master-detail-grid.component.ts
+++ b/src/app/widgets/master-detail/master-detail-grid.component.ts
@@ -1,0 +1,97 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { AgGridModule } from 'ag-grid-angular';
+import { ColDef } from 'ag-grid-community';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-master-detail-grid',
+  standalone: true,
+  templateUrl: './master-detail-grid.component.html',
+  styleUrls: ['./master-detail-grid.component.css'],
+  imports: [CommonModule, AgGridModule, MatCardModule, MatProgressSpinnerModule]
+})
+export class MasterDetailGridComponent implements OnInit {
+  userColumnDefs: ColDef[] = [
+    { field: 'name' },
+    { field: 'username' },
+    { field: 'email' },
+    { headerName: 'Phone', field: 'phone' },
+    {
+      headerName: 'Company',
+      valueGetter: (p) => p.data?.company?.name
+    }
+  ];
+
+  postColumnDefs: ColDef[] = [
+    { field: 'title', headerName: 'Title' },
+    { field: 'body', headerName: 'Body' }
+  ];
+
+  defaultColDef: ColDef = {
+    sortable: true,
+    filter: true,
+    resizable: true,
+    flex: 1,
+    minWidth: 100
+  };
+
+  users: any[] = [];
+  posts: any[] = [];
+  selectedPost?: any;
+  loadingUsers = false;
+  loadingPosts = false;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.loadUsers();
+  }
+
+  loadUsers() {
+    this.loadingUsers = true;
+    this.http
+      .get<any[]>('https://jsonplaceholder.typicode.com/users')
+      .subscribe({
+        next: (data) => {
+          this.users = data;
+          this.loadingUsers = false;
+        },
+        error: () => {
+          this.loadingUsers = false;
+        }
+      });
+  }
+
+  onUserSelected(event: any) {
+    if (event.node.selected) {
+      const userId = event.data.id;
+      this.loadPosts(userId);
+    }
+  }
+
+  loadPosts(userId: number) {
+    this.loadingPosts = true;
+    this.posts = [];
+    this.selectedPost = undefined;
+    this.http
+      .get<any[]>(`https://jsonplaceholder.typicode.com/posts?userId=${userId}`)
+      .subscribe({
+        next: (data) => {
+          this.posts = data;
+          this.loadingPosts = false;
+        },
+        error: () => {
+          this.loadingPosts = false;
+        }
+      });
+  }
+
+  onPostSelected(event: any) {
+    if (event.node.selected) {
+      this.selectedPost = event.data;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add MasterDetailGridComponent using AG Grid and Material cards
- load users and posts from JSONPlaceholder
- show selected post details in a side panel
- register component at `/master-detail` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68764794ccfc832da0ef03cce8a35a2e